### PR TITLE
CircuitOperation proto serialization

### DIFF
--- a/cirq/google/__init__.py
+++ b/cirq/google/__init__.py
@@ -104,11 +104,13 @@ from cirq.google.optimizers import (
 )
 
 from cirq.google.op_deserializer import (
+    CircuitOpDeserializer,
     DeserializingArg,
     GateOpDeserializer,
 )
 
 from cirq.google.op_serializer import (
+    CircuitOpSerializer,
     GateOpSerializer,
     SerializingArg,
 )

--- a/cirq/google/common_serializers.py
+++ b/cirq/google/common_serializers.py
@@ -618,6 +618,11 @@ LIMITED_FSIM_DESERIALIZER = op_deserializer.GateOpDeserializer(
     ],
 )
 
+#############################################
+#
+# Miscellaneous serializers and deserializers
+#
+#############################################
 
 #
 # WaitGate serializer and deserializer
@@ -647,3 +652,9 @@ WAIT_GATE_DESERIALIZER = op_deserializer.GateOpDeserializer(
     ],
     num_qubits_param='num_qubits',
 )
+
+#
+# CircuitOperation serializer and deserializer
+#
+CIRCUIT_OP_SERIALIZER = op_serializer.CircuitOpSerializer()
+CIRCUIT_OP_DESERIALIZER = op_deserializer.CircuitOpDeserializer()

--- a/cirq/google/devices/known_devices.py
+++ b/cirq/google/devices/known_devices.py
@@ -16,7 +16,7 @@ from typing import Any, Collection, Dict, Optional, Iterable, List, Set, Tuple, 
 
 from cirq._doc import document
 from cirq.devices import GridQubit
-from cirq.google import gate_sets, serializable_gate_set
+from cirq.google import gate_sets, op_serializer, serializable_gate_set
 from cirq.google.api import v2
 from cirq.google.api.v2 import device_pb2
 from cirq.google.devices.serializable_device import SerializableDevice
@@ -132,8 +132,8 @@ def create_device_proto_for_qubits(
         gs_proto = out.valid_gate_sets.add()
         gs_proto.name = gate_set.gate_set_name
         gate_ids: Set[str] = set()
-        for gate_type in gate_set.serializers:
-            for serializer in gate_set.serializers[gate_type]:
+        for internal_type in gate_set.serializers:
+            for serializer in gate_set.serializers[internal_type]:
                 gate_id = serializer.serialized_gate_id
                 if gate_id in gate_ids:
                     # Only add each type once
@@ -143,7 +143,13 @@ def create_device_proto_for_qubits(
                 gate = gs_proto.valid_gates.add()
                 gate.id = gate_id
 
+                if not isinstance(serializer, op_serializer.GateOpSerializer):
+                    # This implies that 'serializer' handles non-gate ops,
+                    # such as CircuitOperations. No other properties apply.
+                    continue
+
                 # Choose target set and number of qubits based on gate type.
+                gate_type = internal_type
 
                 # Note: if it is not a measurement gate and doesn't inherit
                 # from SingleQubitGate, it's assumed to be a two qubit gate.

--- a/cirq/google/devices/known_devices_test.py
+++ b/cirq/google/devices/known_devices_test.py
@@ -500,10 +500,6 @@ def test_proto_with_circuitop():
         "aa\naa",
         [circuitop_gateset],
     )
-    circuitop_device = cg.SerializableDevice.from_proto(
-      proto=circuitop_proto,
-      gate_sets=[circuitop_gateset]
-    )
 
     assert (
         str(circuitop_proto)

--- a/cirq/google/devices/known_devices_test.py
+++ b/cirq/google/devices/known_devices_test.py
@@ -490,6 +490,62 @@ def test_sycamore_grid_layout():
         cg.Sycamore23.validate_operation(sqrt_iswap)
 
 
+def test_proto_with_circuitop():
+    circuitop_gateset = cg.serializable_gate_set.SerializableGateSet(
+        gate_set_name='circuitop_gateset',
+        serializers=[cgc.CIRCUIT_OP_SERIALIZER],
+        deserializers=[cgc.CIRCUIT_OP_DESERIALIZER],
+    )
+    circuitop_proto = cg.devices.known_devices.create_device_proto_from_diagram(
+        "aa\naa",
+        [circuitop_gateset],
+    )
+    circuitop_device = cg.SerializableDevice.from_proto(
+      proto=circuitop_proto,
+      gate_sets=[circuitop_gateset]
+    )
+
+    assert (
+        str(circuitop_proto)
+        == """\
+valid_gate_sets {
+  name: "circuitop_gateset"
+  valid_gates {
+    id: "circuit"
+  }
+}
+valid_qubits: "0_0"
+valid_qubits: "0_1"
+valid_qubits: "1_0"
+valid_qubits: "1_1"
+valid_targets {
+  name: "meas_targets"
+  target_ordering: SUBSET_PERMUTATION
+}
+valid_targets {
+  name: "2_qubit_targets"
+  target_ordering: SYMMETRIC
+  targets {
+    ids: "0_0"
+    ids: "0_1"
+  }
+  targets {
+    ids: "0_0"
+    ids: "1_0"
+  }
+  targets {
+    ids: "0_1"
+    ids: "1_1"
+  }
+  targets {
+    ids: "1_0"
+    ids: "1_1"
+  }
+}
+"""
+    )
+
+
 def test_proto_with_waitgate():
     wait_gateset = cg.serializable_gate_set.SerializableGateSet(
         gate_set_name='wait_gateset',

--- a/cirq/google/gate_sets_test.py
+++ b/cirq/google/gate_sets_test.py
@@ -202,11 +202,33 @@ def test_serialize_circuit():
         circuit=v2.program_pb2.Circuit(
             scheduling_strategy=v2.program_pb2.Circuit.MOMENT_BY_MOMENT,
             moments=[
-                v2.program_pb2.Moment(operations=[cg.XMON.serialize_op(cirq.CZ(q0, q1))]),
                 v2.program_pb2.Moment(
-                    operations=[cg.XMON.serialize_op(cirq.X(q0)), cg.XMON.serialize_op(cirq.Z(q1))]
+                    operations=[cg.XMON.serialize_op(cirq.CZ(q0, q1))],
+                    generic_operations=[
+                        v2.program_pb2.GenericOperation(
+                            operation=cg.XMON.serialize_op(cirq.CZ(q0, q1))
+                        ),
+                    ],
                 ),
-                v2.program_pb2.Moment(operations=[cg.XMON.serialize_op(cirq.measure(q1, key='m'))]),
+                v2.program_pb2.Moment(
+                    operations=[cg.XMON.serialize_op(cirq.X(q0)), cg.XMON.serialize_op(cirq.Z(q1))],
+                    generic_operations=[
+                        v2.program_pb2.GenericOperation(
+                            operation=cg.XMON.serialize_op(cirq.X(q0)),
+                        ),
+                        v2.program_pb2.GenericOperation(
+                            operation=cg.XMON.serialize_op(cirq.Z(q1)),
+                        ),
+                    ],
+                ),
+                v2.program_pb2.Moment(
+                    operations=[cg.XMON.serialize_op(cirq.measure(q1, key='m'))],
+                    generic_operations=[
+                        v2.program_pb2.GenericOperation(
+                            operation=cg.XMON.serialize_op(cirq.measure(q1, key='m'))
+                        ),
+                    ],
+                ),
             ],
         ),
     )

--- a/cirq/google/json_test_data/spec.py
+++ b/cirq/google/json_test_data/spec.py
@@ -25,6 +25,8 @@ TestSpec = ModuleJsonTestSpec(
     ],
     should_not_be_serialized=[
         'AnnealSequenceSearchStrategy',
+        'CircuitOpDeserializer',
+        'CircuitOpSerializer',
         'CircuitWithCalibration',
         'ConvertToSqrtIswapGates',
         'ConvertToSycamoreGates',

--- a/cirq/google/op_deserializer.py
+++ b/cirq/google/op_deserializer.py
@@ -226,19 +226,19 @@ class CircuitOpDeserializer(OpDeserializer):
                 f'but it has type {type(circuit)} in the raw_constants list.'
             )
 
-        if not proto.repetition_spec.repetition_ids:
-            repetition_ids = None
-            repetitions = proto.repetition_spec.repetitions
+        if not proto.repetition_spec.rep_ids:
+            rep_ids = None
+            repetitions = proto.repetition_spec.rep_count
         else:
-            repetition_ids = proto.repetition_spec.repetition_ids
-            repetitions = len(repetition_ids)
+            rep_ids = proto.repetition_spec.rep_ids.ids
+            repetitions = len(rep_ids)
 
         qubit_map = {
-            v2.qubit_from_proto_id(pair.first): v2.qubit_from_proto_id(pair.second)
-            for pair in proto.qubit_map
+            v2.qubit_from_proto_id(pair.first.id): v2.qubit_from_proto_id(pair.second.id)
+            for pair in proto.qubit_map.pairs
         }
         measurement_key_map = {
-            pair.first.str_key: pair.second.str_key for pair in proto.measurement_key_map
+            pair.first.str_key: pair.second.str_key for pair in proto.measurement_key_map.pairs
         }
         arg_map = {
             arg_func_langs.arg_from_proto(
@@ -246,7 +246,7 @@ class CircuitOpDeserializer(OpDeserializer):
             ): arg_func_langs.arg_from_proto(
                 pair.second, arg_function_language=arg_function_language
             )
-            for pair in proto.arg_map
+            for pair in proto.arg_map.pairs
         }
 
         for arg in arg_map.keys():
@@ -269,5 +269,5 @@ class CircuitOpDeserializer(OpDeserializer):
             qubit_map,
             measurement_key_map,
             arg_map,  # type: ignore
-            repetition_ids,
+            rep_ids,
         )

--- a/cirq/google/op_deserializer.py
+++ b/cirq/google/op_deserializer.py
@@ -226,7 +226,7 @@ class CircuitOpDeserializer(OpDeserializer):
                 f'but it has type {type(circuit)} in the raw_constants list.'
             )
 
-        if not proto.repetition_spec.rep_ids:
+        if not proto.repetition_spec.rep_ids.ids:
             rep_ids = None
             repetitions = proto.repetition_spec.rep_count
         else:
@@ -251,16 +251,19 @@ class CircuitOpDeserializer(OpDeserializer):
 
         for arg in arg_map.keys():
             if not isinstance(arg, (str, sympy.Symbol)):
+                print('whoopee')
                 raise ValueError(
                     'Invalid key parameter type in deserialized CircuitOperation. '
-                    f'Expected str or sympy.Symbol, found {type(arg)}.\nFull arg: {arg}'
+                    f'Expected str or sympy.Symbol, found {type(arg)}.'
+                    f'\nFull arg: {arg}'
                 )
 
         for arg in arg_map.values():
-            if arg is None:
+            if not isinstance(arg, (str, sympy.Symbol, float, int)):
                 raise ValueError(
                     'Invalid value parameter type in deserialized CircuitOperation. '
-                    f'Expected str or sympy.Symbol, found None.\nFull arg: {arg}'
+                    f'Expected str, sympy.Symbol, or number; found {type(arg)}.'
+                    f'\nFull arg: {arg}'
                 )
 
         return circuits.CircuitOperation(

--- a/cirq/google/op_deserializer_test.py
+++ b/cirq/google/op_deserializer_test.py
@@ -330,7 +330,7 @@ def test_token_with_references():
         deserializer.from_proto(serialized)
 
 
-def test_circuit_proto():
+def default_circuit_proto():
     genop1 = v2.program_pb2.GenericOperation()
     op1 = genop1.operation
     op1.gate.id = 'x_pow'
@@ -348,7 +348,7 @@ def test_circuit_proto():
     )
 
 
-def test_circuit():
+def default_circuit():
     return cirq.FrozenCircuit(
         cirq.X(cirq.GridQubit(1, 1)) ** sympy.Symbol('k'),
         cirq.measure(cirq.GridQubit(1, 1), key='m'),
@@ -359,8 +359,8 @@ def test_circuit_op_from_proto_errors():
     deserializer = cg.CircuitOpDeserializer()
     serialized = v2.program_pb2.CircuitOperation(circuit_constant_index=0)
 
-    constants = [v2.program_pb2.Constant(circuit_value=test_circuit_proto())]
-    raw_constants = [test_circuit()]
+    constants = [v2.program_pb2.Constant(circuit_value=default_circuit_proto())]
+    raw_constants = [default_circuit()]
 
     with pytest.raises(ValueError, match='CircuitOp deserialization requires a constants list'):
         deserializer.from_proto(serialized)
@@ -383,13 +383,10 @@ def test_circuit_op_arg_key_errors():
     p1.first.arg_value.float_value = 1.0
     p1.second.arg_value.float_value = 2.0
 
-    serialized = v2.program_pb2.CircuitOperation(
-        circuit_constant_index=0,
-        arg_map=arg_map
-    )
+    serialized = v2.program_pb2.CircuitOperation(circuit_constant_index=0, arg_map=arg_map)
 
-    constants = [v2.program_pb2.Constant(circuit_value=test_circuit_proto())]
-    raw_constants = [test_circuit()]
+    constants = [v2.program_pb2.Constant(circuit_value=default_circuit_proto())]
+    raw_constants = [default_circuit()]
 
     with pytest.raises(ValueError, match='Invalid key parameter type'):
         deserializer.from_proto(serialized, constants=constants, raw_constants=raw_constants)
@@ -402,13 +399,10 @@ def test_circuit_op_arg_val_errors():
     p1.first.arg_value.string_value = 'k'
     p1.second.arg_value.bool_values.values.extend([True, False])
 
-    serialized = v2.program_pb2.CircuitOperation(
-        circuit_constant_index=0,
-        arg_map=arg_map
-    )
+    serialized = v2.program_pb2.CircuitOperation(circuit_constant_index=0, arg_map=arg_map)
 
-    constants = [v2.program_pb2.Constant(circuit_value=test_circuit_proto())]
-    raw_constants = [test_circuit()]
+    constants = [v2.program_pb2.Constant(circuit_value=default_circuit_proto())]
+    raw_constants = [default_circuit()]
 
     with pytest.raises(ValueError, match='Invalid value parameter type'):
         deserializer.from_proto(serialized, constants=constants, raw_constants=raw_constants)
@@ -443,12 +437,12 @@ def test_circuit_op_from_proto():
         arg_map=arg_map,
     )
 
-    constants = [v2.program_pb2.Constant(circuit_value=test_circuit_proto())]
-    raw_constants = [test_circuit()]
+    constants = [v2.program_pb2.Constant(circuit_value=default_circuit_proto())]
+    raw_constants = [default_circuit()]
 
     actual = deserializer.from_proto(serialized, constants=constants, raw_constants=raw_constants)
     expected = cirq.CircuitOperation(
-        circuit=test_circuit(),
+        circuit=default_circuit(),
         qubit_map={cirq.GridQubit(1, 1): cirq.GridQubit(1, 2)},
         measurement_key_map={'m': 'results'},
         param_resolver={'k': 1.0},

--- a/cirq/google/op_serializer.py
+++ b/cirq/google/op_serializer.py
@@ -327,7 +327,7 @@ class CircuitOpSerializer(OpSerializer):
 
         msg = msg or v2.program_pb2.CircuitOperation()
         try:
-            msg.circuit_constant_index = raw_constants.index(op.untagged.circuit)
+            msg.circuit_constant_index = raw_constants.index(op.circuit)
         except ValueError as err:
             # Circuits must be serialized prior to any CircuitOperations that use them.
             raise ValueError(

--- a/cirq/google/op_serializer.py
+++ b/cirq/google/op_serializer.py
@@ -62,11 +62,6 @@ class OpSerializer(abc.ABC):
     def serialized_gate_id(self) -> str:
         return self.serialized_id
 
-    @property
-    @abc.abstractmethod
-    def args(self):
-        """TODO: determine if this property makes sense."""
-
     @abc.abstractmethod
     def to_proto(
         self,
@@ -302,11 +297,6 @@ class CircuitOpSerializer(OpSerializer):
     @property
     def serialized_id(self):
         return 'circuit'
-
-    @property
-    def args(self):
-        """TODO: this only exists to appease known_devices."""
-        return []
 
     @property
     def can_serialize_predicate(self):

--- a/cirq/google/op_serializer.py
+++ b/cirq/google/op_serializer.py
@@ -178,7 +178,7 @@ class GateOpSerializer(OpSerializer):
         `can_serializer_predicate` called on the gate.
         """
         supported_gate_type = self._gate_type in type(op.gate).mro()
-        return supported_gate_type and self._can_serialize_predicate(op)
+        return supported_gate_type and super().can_serialize_operation(op)
 
     def to_proto(
         self,
@@ -325,13 +325,9 @@ class CircuitOpSerializer(OpSerializer):
         if not isinstance(op, circuits.CircuitOperation):
             raise ValueError(f'Serializer expected CircuitOperation but got {type(op)}.')
 
-        circuit = getattr(op.untagged, 'circuit', None)
-        if circuit is None:
-            return None
-
         msg = msg or v2.program_pb2.CircuitOperation()
         try:
-            msg.circuit_constant_index = raw_constants.index(circuit)
+            msg.circuit_constant_index = raw_constants.index(op.untagged.circuit)
         except ValueError as err:
             # Circuits must be serialized prior to any CircuitOperations that use them.
             raise ValueError(

--- a/cirq/google/op_serializer.py
+++ b/cirq/google/op_serializer.py
@@ -15,9 +15,11 @@
 from dataclasses import dataclass
 from typing import Any, Callable, List, Optional, Type, TypeVar, Union, TYPE_CHECKING
 
+import abc
 import numpy as np
 
-from cirq import ops
+from cirq import circuits, ops
+from cirq._compat import deprecated
 from cirq.google.api import v2
 from cirq.google import arg_func_langs
 from cirq.google.arg_func_langs import arg_to_proto
@@ -28,6 +30,69 @@ if TYPE_CHECKING:
 
 # Type for variables that are subclasses of ops.Gate.
 Gate = TypeVar('Gate', bound=ops.Gate)
+
+
+class OpSerializer(abc.ABC):
+    """Generic supertype for op serializers."""
+
+    @property
+    @abc.abstractmethod
+    def internal_type(self) -> Type:
+        """Returns the type that the operation contains.
+
+        For GateOperations, this is the gate type.
+        For CircuitOperations, this is FrozenCircuit.
+        """
+
+    @property  # type: ignore
+    @deprecated(deadline='v0.12.0', fix='Use internal_type instead.')
+    def gate_type(self) -> Type:
+        return self.internal_type
+
+    @property
+    @abc.abstractmethod
+    def serialized_id(self) -> str:
+        """Returns the string identifier for the resulting serialized object.
+
+        This value should reflect the internal_type of the serializer.
+        """
+
+    @property  # type: ignore
+    @deprecated(deadline='v0.12.0', fix='Use serialized_id instead.')
+    def serialized_gate_id(self) -> str:
+        return self.serialized_id
+
+    @property
+    @abc.abstractmethod
+    def args(self):
+        """TODO: determine if this property makes sense."""
+
+    @abc.abstractmethod
+    def to_proto(
+        self,
+        op,
+        msg: Optional[v2.program_pb2.CircuitOperation] = None,
+        *,
+        arg_function_language: Optional[str] = '',
+        constants: List[v2.program_pb2.Constant] = None,
+        raw_constants: List[Any] = None,
+    ) -> Optional[v2.program_pb2.CircuitOperation]:
+        """Converts op to proto using this serializer.
+
+        If self.can_serialize_operation(op) == false, this should return None.
+        """
+
+    @property
+    @abc.abstractmethod
+    def can_serialize_predicate(self) -> Callable[['cirq.Operation'], bool]:
+        """The method used to determine if this can serialize an operation.
+
+        Depending on the serializer, additional checks may be required.
+        """
+
+    def can_serialize_operation(self, op: 'cirq.Operation') -> bool:
+        """Whether the given operation can be serialized by this serializer."""
+        return self.can_serialize_predicate(op)
 
 
 @dataclass(frozen=True)
@@ -55,7 +120,7 @@ class SerializingArg:
     default: Any = None
 
 
-class GateOpSerializer:
+class GateOpSerializer(OpSerializer):
     """Describes how to serialize a GateOperation for a given Gate type.
 
     Attributes:
@@ -88,11 +153,27 @@ class GateOpSerializer:
                 serializing, including how to get this information from the
                 gate of the given gate type.
         """
-        self.gate_type = gate_type
-        self.serialized_gate_id = serialized_gate_id
-        self.args = args
-        self.can_serialize_predicate = can_serialize_predicate
-        self.serialize_tokens = serialize_tokens
+        self._gate_type = gate_type
+        self._serialized_gate_id = serialized_gate_id
+        self._args = args
+        self._can_serialize_predicate = can_serialize_predicate
+        self._serialize_tokens = serialize_tokens
+
+    @property
+    def internal_type(self):
+        return self._gate_type
+
+    @property
+    def serialized_id(self):
+        return self._serialized_gate_id
+
+    @property
+    def args(self):
+        return self._args
+
+    @property
+    def can_serialize_predicate(self):
+        return self._can_serialize_predicate
 
     def can_serialize_operation(self, op: 'cirq.Operation') -> bool:
         """Whether the given operation can be serialized by this serializer.
@@ -101,8 +182,8 @@ class GateOpSerializer:
         serializer, and that the gate returns true for
         `can_serializer_predicate` called on the gate.
         """
-        supported_gate_type = self.gate_type in type(op.gate).mro()
-        return supported_gate_type and self.can_serialize_predicate(op)
+        supported_gate_type = self._gate_type in type(op.gate).mro()
+        return supported_gate_type and self._can_serialize_predicate(op)
 
     def to_proto(
         self,
@@ -111,6 +192,7 @@ class GateOpSerializer:
         *,
         arg_function_language: Optional[str] = '',
         constants: List[v2.program_pb2.Constant] = None,
+        raw_constants: List[Any] = None,
     ) -> Optional[v2.program_pb2.Operation]:
         """Returns the cirq.google.api.v2.Operation message as a proto dict.
 
@@ -119,21 +201,23 @@ class GateOpSerializer:
         """
 
         gate = op.gate
-        if not isinstance(gate, self.gate_type):
+        if not isinstance(gate, self._gate_type):
             raise ValueError(
-                'Gate of type {} but serializer expected type {}'.format(type(gate), self.gate_type)
+                'Gate of type {} but serializer expected type {}'.format(
+                    type(gate), self._gate_type
+                )
             )
 
-        if not self.can_serialize_predicate(op):
+        if not self._can_serialize_predicate(op):
             return None
 
         if msg is None:
             msg = v2.program_pb2.Operation()
 
-        msg.gate.id = self.serialized_gate_id
+        msg.gate.id = self._serialized_gate_id
         for qubit in op.qubits:
             msg.qubits.add().id = v2.qubit_to_proto_id(qubit)
-        for arg in self.args:
+        for arg in self._args:
             value = self._value_from_gate(op, arg)
             if value is not None and (not arg.default or value != arg.default):
                 arg_to_proto(
@@ -141,7 +225,7 @@ class GateOpSerializer:
                     out=msg.args[arg.serialized_name],
                     arg_function_language=arg_function_language,
                 )
-        if self.serialize_tokens:
+        if self._serialize_tokens:
             for tag in op.tags:
                 if isinstance(tag, CalibrationTag):
                     if constants is not None:
@@ -153,6 +237,8 @@ class GateOpSerializer:
                             # Token not found, add it to the list
                             msg.token_constant_index = len(constants)
                             constants.append(constant)
+                            if raw_constants is not None:
+                                raw_constants.append(tag.token)
                     else:
                         msg.token_value = tag.token
         return msg
@@ -204,3 +290,83 @@ class GateOpSerializer:
                     arg.serialized_name, arg.serialized_type, type(value)
                 )
             )
+
+
+class CircuitOpSerializer(OpSerializer):
+    """Describes how to serialize CircuitOperations."""
+
+    @property
+    def internal_type(self):
+        return circuits.FrozenCircuit
+
+    @property
+    def serialized_id(self):
+        return 'circuit'
+
+    @property
+    def args(self):
+        """TODO: this only exists to appease known_devices."""
+        return []
+
+    @property
+    def can_serialize_predicate(self):
+        return lambda op: isinstance(op.untagged, circuits.CircuitOperation)
+
+    def to_proto(
+        self,
+        op: 'cirq.CircuitOperation',
+        msg: Optional[v2.program_pb2.CircuitOperation] = None,
+        *,
+        arg_function_language: Optional[str] = '',
+        constants: List[v2.program_pb2.Constant] = None,
+        raw_constants: List[Any] = None,
+    ) -> Optional[v2.program_pb2.CircuitOperation]:
+        """Returns the cirq.google.api.v2.CircuitOperation message as a proto dict.
+
+        Note that this function requires the constants and raw_constants lists
+        to be pre-populated with the circuit in op.
+        """
+        if constants is None or raw_constants is None:
+            raise ValueError(
+                'CircuitOp serialization requires a constants list and a corresponding list of '
+                'pre-serialization values (raw_constants).'
+            )
+
+        if not isinstance(op, circuits.CircuitOperation):
+            raise ValueError(f'Serializer expected CircuitOperation but got {type(op)}.')
+
+        circuit = getattr(op.untagged, 'circuit', None)
+        if circuit is None:
+            return None
+
+        msg = msg or v2.program_pb2.CircuitOperation()
+        try:
+            msg.circuit_constant_index = raw_constants.index(circuit)
+        except ValueError as err:
+            # Circuits must be serialized prior to any CircuitOperations that use them.
+            raise ValueError(
+                'Encountered a circuit not in the constants table. ' f'Full error message:\n{err}'
+            )
+
+        if op.repetition_ids:
+            for rep_id in op.repetition_ids:
+                msg.repetition_spec.rep_ids.ids.append(rep_id)
+        else:
+            msg.repetition_spec.rep_count = op.repetitions
+
+        for q1, q2 in op.qubit_map.items():
+            pair = msg.qubit_map.pairs.add()
+            pair.first.id = v2.qubit_to_proto_id(q1)
+            pair.second.id = v2.qubit_to_proto_id(q2)
+
+        for mk1, mk2 in op.measurement_key_map.items():
+            pair = msg.measurement_key_map.pairs.add()
+            pair.first.str_key = mk1
+            pair.second.str_key = mk2
+
+        for p1, p2 in op.param_resolver.param_dict.items():
+            pair = msg.arg_map.pairs.add()
+            arg_to_proto(p1, out=pair.first, arg_function_language=arg_function_language)
+            arg_to_proto(p2, out=pair.second, arg_function_language=arg_function_language)
+
+        return msg

--- a/cirq/google/op_serializer_test.py
+++ b/cirq/google/op_serializer_test.py
@@ -64,6 +64,19 @@ def get_val(op):
     return op.gate.get_val()
 
 
+def test_deprecated_fields():
+    serializer = cg.GateOpSerializer(
+        gate_type=GateWithAttribute,
+        serialized_gate_id='my_gate',
+        args=[],
+    )
+    with pytest.warns(DeprecationWarning, match='Use serialized_id'):
+        assert serializer.serialized_gate_id == serializer.serialized_id
+
+    with pytest.warns(DeprecationWarning, match='Use internal_type'):
+        assert serializer.gate_type == serializer.internal_type
+
+
 TEST_CASES = (
     (float, 1.0, {'arg_value': {'float_value': 1.0}}),
     (str, 'abc', {'arg_value': {'string_value': 'abc'}}),

--- a/cirq/google/op_serializer_test.py
+++ b/cirq/google/op_serializer_test.py
@@ -508,3 +508,4 @@ def test_circuit_op_to_proto():
         arg_map=arg_map,
     )
     actual = serializer.to_proto(to_serialize, constants=constants, raw_constants=raw_constants)
+    assert actual == expected

--- a/cirq/google/serializable_gate_set.py
+++ b/cirq/google/serializable_gate_set.py
@@ -14,6 +14,7 @@
 """Support for serializing and deserializing cirq.google.api.v2 protos."""
 
 from typing import (
+    Any,
     Dict,
     Iterable,
     List,
@@ -21,9 +22,11 @@ from typing import (
     Tuple,
     Type,
     TYPE_CHECKING,
+    Union,
 )
 
 from cirq import circuits, ops
+from cirq._compat import deprecated_parameter
 from cirq.google import op_deserializer, op_serializer, arg_func_langs
 from cirq.google.api import v2
 
@@ -40,34 +43,35 @@ class SerializableGateSet:
     def __init__(
         self,
         gate_set_name: str,
-        serializers: Iterable[op_serializer.GateOpSerializer],
-        deserializers: Iterable[op_deserializer.GateOpDeserializer],
+        serializers: Iterable[op_serializer.OpSerializer],
+        deserializers: Iterable[op_deserializer.OpDeserializer],
     ):
         """Construct the gate set.
 
         Args:
             gate_set_name: The name used to identify the gate set.
-            serializers: The GateOpSerializers to use for serialization.
+            serializers: The OpSerializers to use for serialization.
                 Multiple serializers for a given gate type are allowed and
                 will be checked for a given type in the order specified here.
                 This allows for a given gate type to be serialized into
                 different serialized form depending on the parameters of the
                 gate.
-            deserializers: The GateOpDeserializers to convert serialized
+            deserializers: The OpDeserializers to convert serialized
                 forms of gates to GateOperations.
         """
         self.gate_set_name = gate_set_name
-        self.serializers: Dict[Type, List[op_serializer.GateOpSerializer]] = {}
+        self.serializers: Dict[Type, List[op_serializer.OpSerializer]] = {}
         for s in serializers:
             self.serializers.setdefault(s.gate_type, []).append(s)
         self.deserializers = {d.serialized_gate_id: d for d in deserializers}
 
+    # TODO: naming is now weird
     def with_added_gates(
         self,
         *,
         gate_set_name: Optional[str] = None,
-        serializers: Iterable[op_serializer.GateOpSerializer] = (),
-        deserializers: Iterable[op_deserializer.GateOpDeserializer] = (),
+        serializers: Iterable[op_serializer.OpSerializer] = (),
+        deserializers: Iterable[op_deserializer.OpDeserializer] = (),
     ) -> 'SerializableGateSet':
         """Creates a new gateset with additional (de)serializers.
 
@@ -87,6 +91,7 @@ class SerializableGateSet:
             deserializers=[*self.deserializers.values(), *deserializers],
         )
 
+    # TODO: naming is now weird
     def supported_gate_types(self) -> Tuple:
         return tuple(self.serializers.keys())
 
@@ -94,6 +99,7 @@ class SerializableGateSet:
         """Whether the given object contains only supported operations."""
         return all(self.is_supported_operation(op) for op in ops.flatten_to_ops(op_tree))
 
+    # TODO: needs CircuitOperation-friendly checks
     def is_supported_operation(self, op: 'cirq.Operation') -> bool:
         """Whether or not the given gate can be serialized by this gate set."""
         return any(
@@ -102,13 +108,26 @@ class SerializableGateSet:
             for serializer in self.serializers.get(gate_type, [])
         )
 
+    @deprecated_parameter(
+        deadline='v0.12.0',
+        fix='Use use_constants instead.',
+        parameter_desc='keyword use_constants_table_for_tokens',
+        match=lambda args, kwargs: 'use_constants_table_for_tokens' in kwargs,
+        rewrite=lambda args, kwargs: (
+            args,
+            {
+                ('use_constants' if k == 'use_constants_table_for_tokens' else k): v
+                for k, v in kwargs.items()
+            },
+        ),
+    )
     def serialize(
         self,
         program: 'cirq.Circuit',
         msg: Optional[v2.program_pb2.Program] = None,
         *,
         arg_function_language: Optional[str] = None,
-        use_constants_table_for_tokens: Optional[bool] = True,
+        use_constants: bool = True,
     ) -> v2.program_pb2.Program:
         """Serialize a Circuit to cirq.google.api.v2.Program proto.
 
@@ -119,9 +138,7 @@ class SerializableGateSet:
             msg = v2.program_pb2.Program()
         msg.language.gate_set = self.gate_set_name
         if isinstance(program, circuits.Circuit):
-            constants: Optional[List[v2.program_pb2.Constant]] = (
-                [] if use_constants_table_for_tokens else None
-            )
+            constants: Optional[List[v2.program_pb2.Constant]] = [] if use_constants else None
             self._serialize_circuit(
                 program,
                 msg.circuit,
@@ -146,6 +163,7 @@ class SerializableGateSet:
         *,
         arg_function_language: Optional[str] = '',
         constants: Optional[List[v2.program_pb2.Constant]] = None,
+        raw_constants: Optional[List[Any]] = None,
     ) -> v2.program_pb2.Operation:
         """Serialize an Operation to cirq.google.api.v2.Operation proto.
 
@@ -155,6 +173,37 @@ class SerializableGateSet:
         Returns:
             A dictionary corresponds to the cirq.google.api.v2.Operation proto.
         """
+        circuit = getattr(op.untagged, 'circuit', None)
+        if circuit is not None:
+            if constants is None or raw_constants is None:
+                raise ValueError(
+                    'CircuitOp serialization requires a constants list and a corresponding '
+                    'list of pre-serialization values (raw_constants).'
+                )
+            if circuits.FrozenCircuit in self.serializers:
+                serializer = self.serializers[circuits.FrozenCircuit][0]
+                if circuit not in raw_constants:
+                    subcircuit_msg = v2.program_pb2.Circuit()
+                    self._serialize_circuit(
+                        circuit,
+                        subcircuit_msg,
+                        arg_function_language=arg_function_language,
+                        constants=constants,
+                        raw_constants=raw_constants,
+                    )
+                    constants.append(subcircuit_msg)
+                    raw_constants.append(circuit)
+                proto_msg = serializer.to_proto(
+                    op,
+                    msg,
+                    arg_function_language=arg_function_language,
+                    constants=constants,
+                    raw_constants=raw_constants,
+                )
+                if proto_msg is not None:
+                    return proto_msg
+            raise ValueError(f'Cannot serialize CircuitOperation {op!r}')
+
         gate_type = type(op.gate)
         for gate_type_mro in gate_type.mro():
             # Check all super classes in method resolution order.
@@ -163,11 +212,15 @@ class SerializableGateSet:
                 # None, then skip.
                 for serializer in self.serializers[gate_type_mro]:
                     proto_msg = serializer.to_proto(
-                        op, msg, arg_function_language=arg_function_language, constants=constants
+                        op,
+                        msg,
+                        arg_function_language=arg_function_language,
+                        constants=constants,
+                        raw_constants=raw_constants,
                     )
                     if proto_msg is not None:
                         return proto_msg
-        raise ValueError('Cannot serialize op {!r} of type {}'.format(op, gate_type))
+        raise ValueError(f'Cannot serialize op {op!r} of type {gate_type}')
 
     def deserialize(
         self, proto: v2.program_pb2.Program, device: Optional['cirq.Device'] = None
@@ -210,10 +263,36 @@ class SerializableGateSet:
 
     def deserialize_op(
         self,
+        operation_proto: Union[
+            v2.program_pb2.Operation,
+            v2.program_pb2.CircuitOperation,
+            v2.program_pb2.GenericOperation,
+        ],
+        **kwargs,
+    ) -> 'cirq.Operation':
+        """Disambiguation for operation deserialization."""
+        if isinstance(operation_proto, v2.program_pb2.GenericOperation):
+            which = operation_proto.WhichOneof('op')
+            if which == 'operation':
+                return self.deserialize_gate_op(operation_proto.operation, **kwargs)
+            if which == 'circuit_operation':
+                return self.deserialize_circuit_op(operation_proto.operation, **kwargs)
+
+        if isinstance(operation_proto, v2.program_pb2.Operation):
+            return self.deserialize_gate_op(operation_proto, **kwargs)
+
+        if isinstance(operation_proto, v2.program_pb2.CircuitOperation):
+            return self.deserialize_circuit_op(operation_proto, **kwargs)
+
+        raise NotImplementedError('Program proto does not contain a circuit.')
+
+    def deserialize_gate_op(
+        self,
         operation_proto: v2.program_pb2.Operation,
         *,
         arg_function_language: str = '',
         constants: Optional[List[v2.program_pb2.Constant]] = None,
+        raw_constants: Optional[List[Any]] = None,
     ) -> 'cirq.Operation':
         """Deserialize an Operation from a cirq.google.api.v2.Operation.
 
@@ -228,23 +307,62 @@ class SerializableGateSet:
             raise ValueError('Operation proto does not have a gate.')
 
         gate_id = operation_proto.gate.id
-        if gate_id not in self.deserializers.keys():
+        deserializer = self.deserializers.get(gate_id, None)
+        if deserializer is None:
             raise ValueError(
-                'Unsupported serialized gate with id "{}".'
-                '\n\noperation_proto:\n{}'.format(gate_id, operation_proto)
+                f'Unsupported serialized gate with id "{gate_id}".'
+                f'\n\noperation_proto:\n{operation_proto}'
             )
 
-        return self.deserializers[gate_id].from_proto(
-            operation_proto, arg_function_language=arg_function_language, constants=constants
+        return deserializer.from_proto(
+            operation_proto,
+            arg_function_language=arg_function_language,
+            constants=constants,
+            raw_constants=raw_constants,
+        )
+
+    def deserialize_circuit_op(
+        self,
+        operation_proto: v2.program_pb2.CircuitOperation,
+        *,
+        arg_function_language: str = '',
+        constants: Optional[List[v2.program_pb2.Constant]] = None,
+        raw_constants: Optional[List[Any]] = None,
+    ) -> 'cirq.CircuitOperation':
+        """Deserialize a CircuitOperation from a
+            cirq.google.api.v2.CircuitOperation.
+
+        Args:
+            operation_proto: A dictionary representing a
+                cirq.google.api.v2.CircuitOperation proto.
+
+        Returns:
+            The deserialized CircuitOperation.
+        """
+        deserializer = self.deserializers.get('circuit', None)
+        if deserializer is None:
+            raise ValueError(
+                f'Unsupported serialized CircuitOperation.\n\noperation_proto:\n{operation_proto}'
+            )
+
+        if not isinstance(deserializer, op_deserializer.CircuitOpDeserializer):
+            raise ValueError(f'Deserializer {deserializer} cannot deserialize CircuitOperations.')
+
+        return deserializer.from_proto(
+            operation_proto,
+            arg_function_language=arg_function_language,
+            constants=constants,
+            raw_constants=raw_constants,
         )
 
     def _serialize_circuit(
         self,
-        circuit: 'cirq.Circuit',
+        circuit: 'cirq.AbstractCircuit',
         msg: v2.program_pb2.Circuit,
         *,
         arg_function_language: Optional[str],
         constants: Optional[List[v2.program_pb2.Constant]] = None,
+        raw_constants: Optional[List[Any]] = None,
     ) -> None:
         msg.scheduling_strategy = v2.program_pb2.Circuit.MOMENT_BY_MOMENT
         for moment in circuit:
@@ -255,6 +373,7 @@ class SerializableGateSet:
                     moment_proto.operations.add(),
                     arg_function_language=arg_function_language,
                     constants=constants,
+                    raw_constants=raw_constants,
                 )
 
     def _deserialize_circuit(

--- a/cirq/google/serializable_gate_set.py
+++ b/cirq/google/serializable_gate_set.py
@@ -382,6 +382,12 @@ class SerializableGateSet:
                 f'Unsupported serialized CircuitOperation.\n\noperation_proto:\n{operation_proto}'
             )
 
+        if not isinstance(deserializer, op_deserializer.CircuitOpDeserializer):
+            raise ValueError(
+                'Expected CircuitOpDeserializer for id "circuit", '
+                f'got {deserializer.serialized_id}.'
+            )
+
         return deserializer.from_proto(
             operation_proto,
             arg_function_language=arg_function_language,

--- a/cirq/google/serializable_gate_set.py
+++ b/cirq/google/serializable_gate_set.py
@@ -321,7 +321,7 @@ class SerializableGateSet:
         if isinstance(operation_proto, v2.program_pb2.CircuitOperation):
             return self.deserialize_circuit_op(operation_proto, **kwargs)
 
-        raise NotImplementedError('Program proto does not contain a circuit.')
+        raise ValueError('Generic operation has no operation.')
 
     def deserialize_gate_op(
         self,
@@ -382,9 +382,6 @@ class SerializableGateSet:
                 f'Unsupported serialized CircuitOperation.\n\noperation_proto:\n{operation_proto}'
             )
 
-        if not isinstance(deserializer, op_deserializer.CircuitOpDeserializer):
-            raise ValueError(f'Deserializer {deserializer} cannot deserialize CircuitOperations.')
-
         return deserializer.from_proto(
             operation_proto,
             arg_function_language=arg_function_language,
@@ -433,6 +430,7 @@ class SerializableGateSet:
         for i, moment_proto in enumerate(circuit_proto.moments):
             moment_ops = []
             try_generic = False
+            print('trying basic ops')
             for op in moment_proto.operations:
                 try:
                     moment_ops.append(
@@ -454,6 +452,7 @@ class SerializableGateSet:
                             f'following proto:\n{op}'
                         ) from ex
             if try_generic:
+                print('trying generic')
                 moment_ops = []
                 for gen_op in moment_proto.generic_operations:
                     try:

--- a/cirq/google/serializable_gate_set_test.py
+++ b/cirq/google/serializable_gate_set_test.py
@@ -513,7 +513,6 @@ def default_circuit():
 
 
 def test_serialize_circuit_op_errors():
-    q0 = cirq.GridQubit(1, 1)
     constants = [default_circuit_proto()]
     raw_constants = [default_circuit()]
 
@@ -537,7 +536,6 @@ def test_serialize_circuit_op_errors():
 
 
 def test_deserialize_circuit_op_errors():
-    q0 = cirq.GridQubit(1, 1)
     constants = [default_circuit_proto()]
     raw_constants = [default_circuit()]
 
@@ -555,9 +553,23 @@ def test_deserialize_circuit_op_errors():
             proto, constants=constants, raw_constants=raw_constants
         )
 
+    BAD_CIRCUIT_DESERIALIZER = cg.GateOpDeserializer(
+        serialized_gate_id='circuit',
+        gate_constructor=cirq.ZPowGate,
+        args=[],
+    )
+    BAD_CIRCUIT_DESERIALIZER_GATE_SET = cg.SerializableGateSet(
+        gate_set_name='bad_circuit_gateset',
+        serializers=[CIRCUIT_OP_SERIALIZER],
+        deserializers=[BAD_CIRCUIT_DESERIALIZER],
+    )
+    with pytest.raises(ValueError, match='Expected CircuitOpDeserializer for id "circuit"'):
+        BAD_CIRCUIT_DESERIALIZER_GATE_SET.deserialize_op(
+            proto, constants=constants, raw_constants=raw_constants
+        )
+
 
 def test_serialize_deserialize_circuit_op():
-    q0 = cirq.GridQubit(1, 1)
     constants = [default_circuit_proto()]
     raw_constants = [default_circuit()]
 

--- a/cirq/google/serializable_gate_set_test.py
+++ b/cirq/google/serializable_gate_set_test.py
@@ -66,10 +66,13 @@ Y_DESERIALIZER = cg.GateOpDeserializer(
     ],
 )
 
+CIRCUIT_OP_SERIALIZER = cg.op_serializer.CircuitOpSerializer()
+CIRCUIT_OP_DESERIALIZER = cg.op_deserializer.CircuitOpDeserializer()
+
 MY_GATE_SET = cg.SerializableGateSet(
     gate_set_name='my_gate_set',
-    serializers=[X_SERIALIZER],
-    deserializers=[X_DESERIALIZER],
+    serializers=[X_SERIALIZER, CIRCUIT_OP_SERIALIZER],
+    deserializers=[X_DESERIALIZER, CIRCUIT_OP_DESERIALIZER],
 )
 
 
@@ -80,7 +83,7 @@ def op_proto(json: Dict) -> v2.program_pb2.Operation:
 
 
 def test_supported_gate_types():
-    assert MY_GATE_SET.supported_gate_types() == (cirq.XPowGate,)
+    assert MY_GATE_SET.supported_gate_types() == (cirq.XPowGate, cirq.FrozenCircuit)
 
 
 def test_is_supported():


### PR DESCRIPTION
Follow-up of #3891.

This PR enables concise serialization of `CircuitOperation`s in proto format. All changes are backwards-compatible: circuits without `CircuitOperation`s will continue to use the old proto behavior, but circuits with `CircuitOperation`s will attempt to use the new proto behavior. Sending circuits with `CircuitOperation`s to a client/server that does not support them will fail, as expected.

Includes a basic (de-)serialization test, but otherwise test coverage remains incomplete.